### PR TITLE
feat: 다형성 Like 테이블 분리 및 스키마 재설계

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 .vscode/
 /src/lib/prisma.ts
 /prisma/migrations/
+dist/

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,8 @@ model User {
   deletedAt     DateTime?      @map("deleted_at")
   collections   Collection[]
   comments      Comment[]
-  likes         Like[]
+  photoLikes    PhotoLike[]
+  commentLikes  CommentLike[]
   notifications Notification[]
   photos        Photo[]
   series        Series[]
@@ -42,6 +43,7 @@ model Photo {
   deletedAt     DateTime?         @map("deleted_at")
   inCollections CollectionPhoto[]
   comments      Comment[]
+  likes         PhotoLike[]
   author        User              @relation(fields: [userId], references: [id])
   series        Series[]          @relation("SeriesCover")
   inSeries      SeriesPhoto[]     @relation("SeriesToPhoto")
@@ -60,6 +62,7 @@ model Comment {
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime  @updatedAt @map("updated_at")
   deletedAt DateTime? @map("deleted_at")
+  likes     CommentLike[]
   photo     Photo     @relation(fields: [photoId], references: [id])
   author    User      @relation(fields: [userId], references: [id])
 
@@ -68,18 +71,34 @@ model Comment {
   @@map("comments")
 }
 
-/// 좋아요 (다형성: photo | comment)
-model Like {
-  id           Int          @id @default(autoincrement()) @map("id")
-  userId       Int          @map("user_id")
-  resourceId   Int          @map("resource_id")
-  resourceType ResourceType @map("resource_type")
-  createdAt    DateTime     @default(now()) @map("created_at")
-  user         User         @relation(fields: [userId], references: [id])
+/// 사진 좋아요
+model PhotoLike {
+  id        Int      @id @default(autoincrement()) @map("id")
+  userId    Int      @map("user_id")
+  photoId   Int      @map("photo_id")
+  createdAt DateTime @default(now()) @map("created_at")
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  photo     Photo    @relation(fields: [photoId], references: [id], onDelete: Cascade)
 
+  @@unique([userId, photoId])
   @@index([userId])
-  @@index([resourceId, resourceType])
-  @@map("likes")
+  @@index([photoId])
+  @@map("photo_likes")
+}
+
+/// 댓글 좋아요
+model CommentLike {
+  id        Int      @id @default(autoincrement()) @map("id")
+  userId    Int      @map("user_id")
+  commentId Int      @map("comment_id")
+  createdAt DateTime @default(now()) @map("created_at")
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  comment   Comment  @relation(fields: [commentId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, commentId])
+  @@index([userId])
+  @@index([commentId])
+  @@map("comment_likes")
 }
 
 /// 컬렉션(북마크 모음)
@@ -112,14 +131,14 @@ model CollectionPhoto {
 
 /// 알림
 model Notification {
-  id           Int           @id @default(autoincrement()) @map("id")
-  userId       Int           @map("user_id")
-  content      String        @map("content")
-  isRead       Boolean       @default(false) @map("is_read")
-  resourceId   Int?          @map("resource_id")
-  resourceType ResourceType? @map("resource_type")
-  createdAt    DateTime      @default(now()) @map("created_at")
-  receiver     User          @relation(fields: [userId], references: [id])
+  id           Int     @id @default(autoincrement()) @map("id")
+  userId       Int     @map("user_id")
+  content      String  @map("content")
+  isRead       Boolean @default(false) @map("is_read")
+  resourceId   Int?    @map("resource_id")
+  resourceType String? @map("resource_type")
+  createdAt    DateTime @default(now()) @map("created_at")
+  receiver     User    @relation(fields: [userId], references: [id])
 
   @@index([userId])
   @@map("notifications")
@@ -156,9 +175,4 @@ model SeriesPhoto {
   @@unique([seriesId, photoId])
   @@index([seriesId, position])
   @@map("series_photos")
-}
-
-enum ResourceType {
-  photo
-  comment
 }

--- a/src/services/photo.service.ts
+++ b/src/services/photo.service.ts
@@ -12,40 +12,39 @@ const prisma = new PrismaClient();
 export const getPhotos = async (sortBy: string) => {
     // 'popular' (인기순)으로 정렬하는 경우
     if (sortBy === 'popular') {
-        // 1. 'photo' 타입의 '좋아요'를 resourceId(사진 ID)로 그룹화하여 각 사진의 좋아요 수를 계산합니다.
-        const popularPhotos = await prisma.like.groupBy({
-            by: ['resourceId'],
-            where: {
-                resourceType: 'photo', // 'photo' 타입의 좋아요만 필터링
-            },
-            _count: {
-                resourceId: true, // resourceId의 개수를 셉니다 (즉, 좋아요 수)
-            },
-            orderBy: {
-                _count: {
-                    resourceId: 'desc', // 좋아요 수가 많은 순서대로 내림차순 정렬
-                },
-            },
-        });
-
-        // 2. 인기순으로 정렬된 사진 ID 목록을 추출합니다.
-        const photoIds = popularPhotos.map((p) => p.resourceId);
-
-        // 3. 추출된 사진 ID 목록을 사용하여 해당 사진들의 전체 정보를 조회합니다.
-        //    (이때, 사진 자체는 최신순으로 보여주는 것이 일반적이므로 createdAt으로 정렬)
+        // Photo 모델을 직접 쿼리하면서, 관계된 PhotoLike의 개수(likes._count)를 기준으로 정렬합니다.
+        // 이 방식은 좋아요가 없는 사진도 결과에 포함시킵니다.
         return prisma.photo.findMany({
-            where: {
-                id: {
-                    in: photoIds, // 인기 있는 사진 ID 목록에 포함된 사진만 조회
-                },
+            include: {
+                // 좋아요 수를 계산하기 위해 likes 관계를 포함시킵니다.
+                // 실제 좋아요 데이터를 모두 가져올 필요는 없으므로, select를 통해 필요한 정보만 제한할 수 있으나,
+                // 여기서는 _count를 위해 전체를 포함합니다.
+                likes: true,
+                author: {
+                    select: {
+                        id: true,
+                        username: true,
+                    }
+                }
             },
             orderBy: {
-                createdAt: 'desc', // 사진은 최신순으로 정렬
+                // likes 관계의 개수(count)를 기준으로 내림차순 정렬합니다.
+                likes: {
+                    _count: 'desc',
+                },
             },
         });
     } else {
         // 'latest' (최신순) 또는 그 외의 경우, 모든 사진을 최신순으로 정렬하여 반환합니다.
         return prisma.photo.findMany({
+            include: {
+                author: {
+                    select: {
+                        id: true,
+                        username: true,
+                    }
+                }
+            },
             orderBy: {
                 createdAt: 'desc', // 생성일(createdAt) 기준으로 내림차순 정렬
             },


### PR DESCRIPTION
기존의 다형성 구조를 가진 Like 테이블을 PhotoLike와 CommentLike 테이블로 분리하여 관계를 명확히 하고, 향후 확장성을 개선합니다.

- Prisma 스키마에서 Like 모델을 제거하고 PhotoLike, CommentLike 모델 추가
- 스키마 변경에 따라 getPhotos 서비스의 인기순 정렬 로직 수정
- .gitignore에 dist 디렉토리 추가