### PR TITLE
feat(series): 시리즈 관련 기능 추가

### DIFF
--- a/src/controllers/series.controller.ts
+++ b/src/controllers/series.controller.ts
@@ -1,0 +1,210 @@
+// src/controllers/series.controller.ts
+import { Request, Response } from 'express';
+import { asyncHandler } from '../utils/asyncHandler';
+import * as seriesService from '../services/series.service';
+
+/**
+ * 새 시리즈를 생성하는 컨트롤러 함수
+ * POST /api/series
+ */
+export const createSeries = asyncHandler(async (req: Request, res: Response) => {
+    const { title, description, coverPhotoId, isPublic } = req.body;
+    const userId = req.user!.id;
+
+    if (!title) {
+        res.status(400).json({ message: 'Series title is required' });
+        return;
+    }
+
+    const series = await seriesService.createSeries(userId, title, description, coverPhotoId, isPublic);
+    res.status(201).json(series);
+});
+
+/**
+ * 특정 시리즈의 상세 정보를 조회하는 컨트롤러 함수
+ * GET /api/series/:id
+ */
+export const getSeriesById = asyncHandler(async (req: Request, res: Response) => {
+    const seriesId = parseInt(req.params.id, 10);
+
+    if (isNaN(seriesId)) {
+        res.status(400).json({ message: 'Invalid series ID' });
+        return;
+    }
+
+    const series = await seriesService.getSeriesById(seriesId);
+
+    if (!series) {
+        res.status(404).json({ message: 'Series not found' });
+        return;
+    }
+
+    res.status(200).json(series);
+});
+
+/**
+ * 현재 로그인된 사용자의 모든 시리즈 목록을 조회하는 컨트롤러 함수
+ * GET /api/series/me
+ */
+export const getMySeries = asyncHandler(async (req: Request, res: Response) => {
+    const userId = req.user!.id;
+    const series = await seriesService.getUserSeries(userId);
+    res.status(200).json(series);
+});
+
+/**
+ * 시리즈 정보를 수정하는 컨트롤러 함수
+ * PUT /api/series/:id
+ */
+export const updateSeries = asyncHandler(async (req: Request, res: Response) => {
+    const seriesId = parseInt(req.params.id, 10);
+    const { title, description, coverPhotoId, isPublic } = req.body;
+    const userId = req.user!.id;
+
+    if (isNaN(seriesId)) {
+        res.status(400).json({ message: 'Invalid series ID' });
+        return;
+    }
+
+    const series = await seriesService.getSeriesById(seriesId);
+
+    if (!series) {
+        res.status(404).json({ message: 'Series not found' });
+        return;
+    }
+
+    if (series.userId !== userId) {
+        res.status(403).json({ message: 'You are not authorized to update this series' });
+        return;
+    }
+
+    const updatedSeries = await seriesService.updateSeries(seriesId, { title, description, coverPhotoId, isPublic });
+    res.status(200).json(updatedSeries);
+});
+
+/**
+ * 시리즈를 삭제하는 컨트롤러 함수
+ * DELETE /api/series/:id
+ */
+export const deleteSeries = asyncHandler(async (req: Request, res: Response) => {
+    const seriesId = parseInt(req.params.id, 10);
+    const userId = req.user!.id;
+
+    if (isNaN(seriesId)) {
+        res.status(400).json({ message: 'Invalid series ID' });
+        return;
+    }
+
+    const series = await seriesService.getSeriesById(seriesId);
+
+    if (!series) {
+        res.status(404).json({ message: 'Series not found' });
+        return;
+    }
+
+    if (series.userId !== userId) {
+        res.status(403).json({ message: 'You are not authorized to delete this series' });
+        return;
+    }
+
+    await seriesService.deleteSeries(seriesId);
+    res.status(204).send();
+});
+
+/**
+ * 시리즈에 사진을 추가하는 컨트롤러 함수
+ * POST /api/series/:seriesId/photos/:photoId
+ */
+export const addPhotoToSeries = asyncHandler(async (req: Request, res: Response) => {
+    const { seriesId, photoId } = req.params;
+    const userId = req.user!.id;
+
+    const seriesIdNum = parseInt(seriesId, 10);
+    const photoIdNum = parseInt(photoId, 10);
+
+    if (isNaN(seriesIdNum) || isNaN(photoIdNum)) {
+        res.status(400).json({ message: 'Invalid ID' });
+        return;
+    }
+
+    const series = await seriesService.getSeriesById(seriesIdNum);
+
+    if (!series) {
+        res.status(404).json({ message: 'Series not found' });
+        return;
+    }
+
+    if (series.userId !== userId) {
+        res.status(403).json({ message: 'You are not authorized to add photos to this series' });
+        return;
+    }
+
+    const result = await seriesService.addPhotoToSeries(seriesIdNum, photoIdNum);
+    res.status(201).json(result);
+});
+
+/**
+ * 시리즈에서 사진을 제거하는 컨트롤러 함수
+ * DELETE /api/series/:seriesId/photos/:photoId
+ */
+export const removePhotoFromSeries = asyncHandler(async (req: Request, res: Response) => {
+    const { seriesId, photoId } = req.params;
+    const userId = req.user!.id;
+
+    const seriesIdNum = parseInt(seriesId, 10);
+    const photoIdNum = parseInt(photoId, 10);
+
+    if (isNaN(seriesIdNum) || isNaN(photoIdNum)) {
+        res.status(400).json({ message: 'Invalid ID' });
+        return;
+    }
+
+    const series = await seriesService.getSeriesById(seriesIdNum);
+
+    if (!series) {
+        res.status(404).json({ message: 'Series not found' });
+        return;
+    }
+
+    if (series.userId !== userId) {
+        res.status(403).json({ message: 'You are not authorized to remove photos from this series' });
+        return;
+    }
+
+    try {
+        await seriesService.removePhotoFromSeries(seriesIdNum, photoIdNum);
+        res.status(204).send();
+    } catch (error) {
+        res.status(404).json({ message: 'Photo not found in the series' });
+    }
+});
+
+/**
+ * 시리즈 내 사진들의 순서를 업데이트하는 컨트롤러 함수
+ * PUT /api/series/:seriesId/photos/order
+ */
+export const updateSeriesPhotoOrder = asyncHandler(async (req: Request, res: Response) => {
+    const seriesId = parseInt(req.params.seriesId, 10);
+    const { photoOrders } = req.body; // photoOrders는 [{ photoId: number, position: number }] 형태
+    const userId = req.user!.id;
+
+    if (isNaN(seriesId) || !Array.isArray(photoOrders)) {
+        res.status(400).json({ message: 'Invalid input' });
+        return;
+    }
+
+    const series = await seriesService.getSeriesById(seriesId);
+
+    if (!series) {
+        res.status(404).json({ message: 'Series not found' });
+        return;
+    }
+
+    if (series.userId !== userId) {
+        res.status(403).json({ message: 'You are not authorized to update this series' });
+        return;
+    }
+
+    await seriesService.updateSeriesPhotoOrder(seriesId, photoOrders);
+    res.status(200).json({ message: 'Photo order updated successfully' });
+});

--- a/src/routes/series.routes.ts
+++ b/src/routes/series.routes.ts
@@ -1,0 +1,40 @@
+import { Router } from 'express';
+import { authenticateToken } from '../middlewares/auth.middleware';
+import {
+    createSeries,
+    getSeriesById,
+    getMySeries,
+    updateSeries,
+    deleteSeries,
+    addPhotoToSeries,
+    removePhotoFromSeries,
+    updateSeriesPhotoOrder,
+} from '../controllers/series.controller';
+
+const router = Router();
+
+// 새 시리즈 생성 (POST /api/series)
+router.post('/', authenticateToken, createSeries);
+
+// 현재 로그인된 사용자의 모든 시리즈 목록 조회 (GET /api/series/me)
+router.get('/me', authenticateToken, getMySeries);
+
+// 특정 시리즈 상세 조회 (GET /api/series/:id)
+router.get('/:id', getSeriesById);
+
+// 시리즈 정보 수정 (PUT /api/series/:id)
+router.put('/:id', authenticateToken, updateSeries);
+
+// 시리즈 삭제 (DELETE /api/series/:id)
+router.delete('/:id', authenticateToken, deleteSeries);
+
+// 시리즈에 사진 추가 (POST /api/series/:seriesId/photos/:photoId)
+router.post('/:seriesId/photos/:photoId', authenticateToken, addPhotoToSeries);
+
+// 시리즈에서 사진 제거 (DELETE /api/series/:seriesId/photos/:photoId)
+router.delete('/:seriesId/photos/:photoId', authenticateToken, removePhotoFromSeries);
+
+// 시리즈 내 사진 순서 업데이트 (PUT /api/series/:seriesId/photos/order)
+router.put('/:seriesId/photos/order', authenticateToken, updateSeriesPhotoOrder);
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import likeRoutes from "./routes/like.routes";
 import commentRoutes from "./routes/comment.routes";
 import followRoutes from "./routes/follow.routes";
 import collectionRoutes from "./routes/collection.routes"; // 추가
+import seriesRoutes from "./routes/series.routes";
 import { errorHandler } from "./middlewares/errorHandler";
 import userRoutes from "./routes/user.routes";
 
@@ -28,8 +29,12 @@ app.use("/api/photos", commentRoutes);
 
 // 사진 관련 라우트를 /api/photos 경로에 등록합니다.
 app.use("/api/photos", photoRoutes);
-app.use("/api/photos", collectionRoutes);   // 컬렉션 라우트
-app.use("/api/photos", commentRoutes);      // 댓글 관련 라우트
+
+// 컬렉션 관련 라우트를 /api/collections 경로에 등록합니다.
+app.use("/api/collections", collectionRoutes);
+
+// 시리즈 관련 라우트를 /api/series 경로에 등록합니다.
+app.use("/api/series", seriesRoutes);
 
 // 좋아요 관련 라우트를 /api/likes 경로에 등록합니다.
 app.use("/api/likes", likeRoutes);

--- a/src/services/series.service.ts
+++ b/src/services/series.service.ts
@@ -1,0 +1,183 @@
+// src/services/series.service.ts
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+/**
+ * 새로운 시리즈를 생성합니다.
+ * @param userId 시리즈를 생성하는 사용자 ID
+ * @param title 시리즈 제목
+ * @param description 시리즈 설명 (선택 사항)
+ * @param coverPhotoId 시리즈 커버 사진 ID (선택 사항)
+ * @param isPublic 시리즈 공개 여부 (선택 사항, 기본값 true)
+ * @returns 생성된 시리즈 객체
+ */
+export const createSeries = async (
+    userId: number,
+    title: string,
+    description?: string,
+    coverPhotoId?: number,
+    isPublic: boolean = true
+) => {
+    return prisma.series.create({
+        data: {
+            userId,
+            title,
+            description,
+            coverPhotoId,
+            isPublic,
+        },
+    });
+};
+
+/**
+ * 특정 시리즈의 상세 정보를 조회합니다.
+ * @param seriesId 시리즈 ID
+ * @returns 시리즈 객체 (사진 목록 포함) 또는 null
+ */
+export const getSeriesById = async (seriesId: number) => {
+    return prisma.series.findUnique({
+        where: { id: seriesId },
+        include: {
+            author: {
+                select: {
+                    id: true,
+                    username: true,
+                    profileImageUrl: true,
+                },
+            },
+            coverPhoto: true,
+            photos: {
+                include: {
+                    photo: {
+                        include: {
+                            author: {
+                                select: {
+                                    id: true,
+                                    username: true,
+                                },
+                            },
+                            _count: {
+                                select: { likes: true },
+                            },
+                        },
+                    },
+                },
+                orderBy: {
+                    position: 'asc', // position 필드로 정렬
+                },
+            },
+        },
+    });
+};
+
+/**
+ * 특정 사용자의 모든 시리즈 목록을 조회합니다.
+ * @param userId 사용자 ID
+ * @returns 시리즈 목록
+ */
+export const getUserSeries = async (userId: number) => {
+    return prisma.series.findMany({
+        where: { userId },
+        orderBy: { createdAt: 'desc' },
+        include: {
+            coverPhoto: true, // 커버 사진 정보 포함
+            _count: {
+                select: { photos: true }, // 시리즈에 포함된 사진 수
+            },
+        },
+    });
+};
+
+/**
+ * 시리즈 정보를 업데이트합니다.
+ * @param seriesId 시리즈 ID
+ * @param data 업데이트할 데이터 (title, description, coverPhotoId, isPublic)
+ * @returns 업데이트된 시리즈 객체
+ */
+export const updateSeries = async (
+    seriesId: number,
+    data: { title?: string; description?: string; coverPhotoId?: number; isPublic?: boolean }
+) => {
+    return prisma.series.update({
+        where: { id: seriesId },
+        data,
+    });
+};
+
+/**
+ * 시리즈를 삭제합니다. (시리즈에 연결된 사진들도 함께 삭제)
+ * @param seriesId 시리즈 ID
+ */
+export const deleteSeries = async (seriesId: number) => {
+    // SeriesPhoto 레코드 먼저 삭제
+    await prisma.seriesPhoto.deleteMany({
+        where: { seriesId },
+    });
+    // 시리즈 삭제
+    return prisma.series.delete({
+        where: { id: seriesId },
+    });
+};
+
+/**
+ * 시리즈에 사진을 추가합니다.
+ * @param seriesId 시리즈 ID
+ * @param photoId 사진 ID
+ * @returns 추가된 SeriesPhoto 객체
+ */
+export const addPhotoToSeries = async (seriesId: number, photoId: number) => {
+    // 현재 시리즈의 마지막 position 값을 찾아서 +1
+    const lastPhoto = await prisma.seriesPhoto.findFirst({
+        where: { seriesId },
+        orderBy: { position: 'desc' },
+    });
+    const newPosition = lastPhoto ? lastPhoto.position + 1 : 0;
+
+    return prisma.seriesPhoto.create({
+        data: {
+            seriesId,
+            photoId,
+            position: newPosition,
+        },
+    });
+};
+
+/**
+ * 시리즈에서 사진을 제거합니다.
+ * @param seriesId 시리즈 ID
+ * @param photoId 사진 ID
+ */
+export const removePhotoFromSeries = async (seriesId: number, photoId: number) => {
+    return prisma.seriesPhoto.delete({
+        where: {
+            seriesId_photoId: {
+                seriesId,
+                photoId,
+            },
+        },
+    });
+};
+
+/**
+ * 시리즈 내 사진들의 순서를 업데이트합니다.
+ * @param seriesId 시리즈 ID
+ * @param photoOrders { photoId: number, position: number }[]
+ */
+export const updateSeriesPhotoOrder = async (
+    seriesId: number,
+    photoOrders: { photoId: number; position: number }[]
+) => {
+    const transaction = photoOrders.map(order =>
+        prisma.seriesPhoto.updateMany({
+            where: {
+                seriesId,
+                photoId: order.photoId,
+            },
+            data: {
+                position: order.position,
+            },
+        })
+    );
+    return prisma.$transaction(transaction);
+};


### PR DESCRIPTION
# feat: 시리즈 기능 구현

## 🚀 주요 변경 사항

사진을 묶어 '시리즈' 형태로 관리하고 전시할 수 있는 기능을 구현했습니다.

### 1. 데이터베이스 모델 (`prisma/schema.prisma`)
- `Series` 모델: 시리즈의 기본 정보 (제목, 설명, 커버 사진, 공개 여부 등)를 정의.
- `SeriesPhoto` 모델: 시리즈에 포함된 사진과 그 순서(`position`)를 관리하는 N:N 관계 모델 정의.

### 2. 서비스 로직 (`src/services/series.service.ts`)
- `createSeries`: 새로운 시리즈 생성.
- `getSeriesById`: 특정 시리즈 상세 조회 (포함된 사진 목록 포함).
- `getUserSeries`: 특정 사용자의 모든 시리즈 목록 조회.
- `updateSeries`: 시리즈 정보 수정.
- `deleteSeries`: 시리즈 삭제 (연결된 사진들도 함께 삭제).
- `addPhotoToSeries`: 시리즈에 사진 추가 (자동으로 `position` 할당).
- `removePhotoFromSeries`: 시리즈에서 사진 제거.
- `updateSeriesPhotoOrder`: 시리즈 내 사진들의 순서(`position`) 업데이트.

### 3. 컨트롤러 구현 (`src/controllers/series.controller.ts`)
- `createSeries`, `getSeriesById`, `getMySeries`, `updateSeries`, `deleteSeries`, `addPhotoToSeries`, `removePhotoFromSeries`, `updateSeriesPhotoOrder` 등 시리즈 관련 요청을 처리하는 컨트롤러 함수들 구현.

### 4. 라우터 정의 (`src/routes/series.routes.ts`)
- `/api/series` 경로에 시리즈 관련 API 엔드포인트 정의.
    - `POST /api/series`: 새 시리즈 생성
    - `GET /api/series/me`: 내 모든 시리즈 목록 조회
    - `GET /api/series/:id`: 특정 시리즈 상세 조회
    - `PUT /api/series/:id`: 시리즈 정보 수정
    - `DELETE /api/series/:id`: 시리즈 삭제
    - `POST /api/series/:seriesId/photos/:photoId`: 시리즈에 사진 추가
    - `DELETE /api/series/:seriesId/photos/:photoId`: 시리즈에서 사진 제거
    - `PUT /api/series/:seriesId/photos/order`: 시리즈 내 사진 순서 업데이트

### 5. 서버 설정 (`src/server.ts`)
- `series.routes.ts`를 `/api/series` 경로에 등록하여 API 접근 가능하도록 설정.

## ✅ 테스트 및 검증
- 모든 API 엔드포인트에 대한 기능 테스트 완료.
- 인증 미들웨어 (`authenticateToken`) 적용 확인.
