### PR TITLE
feat(follow): 팔로우 토글 및 팔로우 상태 표시 기능 구현

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,8 +23,8 @@ model User {
   likes                 Like[]
   photos                Photo[]
   series                Series[]
-  followers             Follow[]         @relation("FollowsTo")
-  following             Follow[]         @relation("FollowsFrom")
+  followers             Follow[]         @relation("Following")
+  following             Follow[]         @relation("Follower")
   receivedNotifications Notification[]   @relation("UserReceivedNotifications")
   sentNotifications     Notification[]   @relation("UserSentNotifications")
 
@@ -33,16 +33,16 @@ model User {
 
 // 팔로우 관계
 model Follow {
-  id          Int          @id @default(autoincrement())
+  id          Int      @id @default(autoincrement())
   followerId  Int
   followingId Int
-  createdAt   DateTime     @default(now())
-  follower    User         @relation("FollowsFrom", fields: [followerId], references: [id])
-  following   User         @relation("FollowsTo", fields: [followingId], references: [id])
-  notifications Notification[]
+  createdAt   DateTime @default(now())
+
+  follower  User @relation("Follower", fields: [followerId], references: [id], onDelete: Cascade)
+  following User @relation("Following", fields: [followingId], references: [id], onDelete: Cascade)
+  notifications Notification[] @relation("NotificationToFollow")
 
   @@unique([followerId, followingId])
-  @@map("follows")
 }
 
 /// 사진(게시물)
@@ -171,7 +171,7 @@ model Notification {
   series    Series?  @relation(fields: [seriesId], references: [id])
   comment   Comment? @relation(fields: [commentId], references: [id])
   like      Like?    @relation(fields: [likeId], references: [id])
-  follow    Follow?  @relation(fields: [followId], references: [id])
+  follow    Follow?  @relation("NotificationToFollow", fields: [followId], references: [id])
 
   @@index([userId])
   @@map("notifications")

--- a/src/controllers/collection.controller.ts
+++ b/src/controllers/collection.controller.ts
@@ -26,7 +26,8 @@ export const toggleCollection = asyncHandler(async (req: Request, res: Response)
  */
 export const getMyCollections = asyncHandler(async (req: Request, res: Response) => {
     const userId = req.user!.id;
-    const photos = await collectionService.getDefaultCollectionPhotos(userId);
+    const currentUserId = req.user?.id;
+    const photos = await collectionService.getDefaultCollectionPhotos(userId, currentUserId);
 
     const photosWithLikeCount = photos.map(item => ({
         ...item.photo,
@@ -69,13 +70,14 @@ export const getUserCollections = asyncHandler(async (req: Request, res: Respons
  */
 export const getCollectionById = asyncHandler(async (req: Request, res: Response) => {
     const collectionId = parseInt(req.params.id, 10);
+    const currentUserId = req.user?.id;
 
     if (isNaN(collectionId)) {
         res.status(400).json({ message: 'Invalid collection ID' });
         return;
     }
 
-    const collection = await collectionService.getCollectionDetails(collectionId);
+    const collection = await collectionService.getCollectionDetails(collectionId, currentUserId);
 
     if (!collection) {
         res.status(404).json({ message: 'Collection not found' });

--- a/src/controllers/follow.controller.ts
+++ b/src/controllers/follow.controller.ts
@@ -3,28 +3,11 @@ import { asyncHandler } from '../utils/asyncHandler';
 import * as followService from '../services/follow.service';
 
 /**
- * 팔로우하는 컨트롤러 함수
- * @param req Express의 Request 객체. `req.params.id`로 팔로우할 사용자의 ID를 받습니다.
- * @param res Express의 Response 객체. 생성된 팔로우 정보 또는 에러 메시지를 반환합니다.
-*/
-export const followUser = asyncHandler(async (req: Request, res: Response) => {
-    const followerId = req.user?.id;
-    const followingId = Number(req.params.id);
-
-    if (!followerId) {
-        return res.status(401).json({ message: 'Unauthorized' });
-    }
-
-    const follow = await followService.followUser(followerId, followingId);
-    res.status(201).json(follow);
-});
-
-/**
- * 언팔로우하는 컨트롤러 함수
- * @param req Express의 Request 객체. `req.params.id`로 언팔로우할 사용자의 ID를 받습니다.
- * @param res Express의 Response 객체. 성공 메시지 또는 에러 메시지를 반환합니다.
+ * 팔로우/언팔로우 토글 컨트롤러 함수
+ * @param req Express의 Request 객체. `req.params.id`로 토글할 사용자의 ID를 받습니다.
+ * @param res Express의 Response 객체. 작업 결과를 반환합니다.
  */
-export const unfollowUser = asyncHandler(async (req: Request, res: Response) => {
+export const toggleFollow = asyncHandler(async (req: Request, res: Response) => {
     const followerId = req.user?.id;
     const followingId = Number(req.params.id);
 
@@ -32,8 +15,8 @@ export const unfollowUser = asyncHandler(async (req: Request, res: Response) => 
         return res.status(401).json({ message: 'Unauthorized' });
     }
 
-    await followService.unfollowUser(followerId, followingId);
-    res.status(204).send();
+    const result = await followService.toggleFollow(followerId, followingId);
+    res.status(200).json(result);
 });
 
 /**

--- a/src/controllers/photo.controller.ts
+++ b/src/controllers/photo.controller.ts
@@ -5,8 +5,9 @@ import { asyncHandler } from '../utils/asyncHandler';
 
 export const getPhotos = asyncHandler(async (req: Request, res: Response) => {
     const sortBy = req.query.sortBy as string;
+    const currentUserId = req.user?.id;
 
-    const photos = await photoService.getPhotos(sortBy);
+    const photos = await photoService.getPhotos(sortBy, currentUserId);
     const photosWithLikeCount = photos.map(photo => ({
         ...photo,
         likesCount: photo._count.likes,
@@ -23,12 +24,13 @@ export const getPhotos = asyncHandler(async (req: Request, res: Response) => {
  */
 export const getPhotoById = asyncHandler(async (req: Request, res: Response) => {
     const photoId = parseInt(req.params.id, 10);
+    const currentUserId = req.user?.id;
 
     if (isNaN(photoId)) {
         return res.status(400).json({ message: 'Invalid photo ID' });
     }
 
-    const photo = await photoService.getPhotoById(photoId);
+    const photo = await photoService.getPhotoById(photoId, currentUserId);
 
     if (!photo) {
         res.status(404).json({ message: 'PHOTO_NOT_FOUND' });

--- a/src/controllers/series.controller.ts
+++ b/src/controllers/series.controller.ts
@@ -26,13 +26,14 @@ export const createSeries = asyncHandler(async (req: Request, res: Response) => 
  */
 export const getSeriesById = asyncHandler(async (req: Request, res: Response) => {
     const seriesId = parseInt(req.params.id, 10);
+    const currentUserId = req.user?.id;
 
     if (isNaN(seriesId)) {
         res.status(400).json({ message: 'Invalid series ID' });
         return;
     }
 
-    const series = await seriesService.getSeriesById(seriesId);
+    const series = await seriesService.getSeriesById(seriesId, currentUserId);
 
     if (!series) {
         res.status(404).json({ message: 'Series not found' });
@@ -48,7 +49,7 @@ export const getSeriesById = asyncHandler(async (req: Request, res: Response) =>
  */
 export const getMySeries = asyncHandler(async (req: Request, res: Response) => {
     const userId = req.user!.id;
-    const series = await seriesService.getUserSeries(userId);
+    const series = await seriesService.getUserSeries(userId, userId);
     res.status(200).json(series);
 });
 

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -7,7 +7,7 @@ import * as photoService from '../services/photo.service';
 export const getMyProfile = asyncHandler(async (req: Request, res: Response) => {
 
     const userId = req.user!.id;
-    const profile = await userService.getUserProfile(userId);
+    const profile = await userService.getUserProfile(userId, userId);
     res.status(200).json(profile);
 });
 

--- a/src/routes/follow.routes.ts
+++ b/src/routes/follow.routes.ts
@@ -1,19 +1,15 @@
 import { Router } from 'express';
 import {
-    followUser,
-    unfollowUser,
+    toggleFollow,
     getFollowers,
     getFollowing,
-    isFollowing
 } from '../controllers/follow.controller';
 import { authenticateToken } from '../middlewares/auth.middleware';
 
 const router = Router();
 
-router.post('/:id/follow', authenticateToken, followUser);
-router.delete('/:id/follow', authenticateToken, unfollowUser);
+router.post('/:id/toggle-follow', authenticateToken, toggleFollow);
 router.get('/:id/followers', getFollowers);
 router.get('/:id/following', getFollowing);
-router.get('/:id/follow-status', authenticateToken, isFollowing);
 
 export default router;

--- a/src/services/collection.service.ts
+++ b/src/services/collection.service.ts
@@ -1,7 +1,10 @@
-// src/services/collection.service.ts
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, User } from '@prisma/client';
+import { isFollowing } from './follow.service';
 
 const prisma = new PrismaClient();
+
+type AuthorWithFollowStatus = Pick<User, 'id' | 'username'> & { isFollowed: boolean };
+type OwnerWithFollowStatus = Pick<User, 'id' | 'username'> & { isFollowed: boolean };
 
 /**
  * 사용자의 기본 컬렉션을 찾거나 생성합니다.
@@ -67,12 +70,13 @@ export const togglePhotoInDefaultCollection = async (userId: number, photoId: nu
 /**
  * 사용자의 기본 컬렉션에 있는 사진 목록을 조회합니다.
  * @param userId 사용자 ID
+ * @param currentUserId 현재 로그인된 사용자의 ID (선택 사항)
  * @returns 컬렉션에 담긴 사진 목록
  */
-export const getDefaultCollectionPhotos = async (userId: number) => {
+export const getDefaultCollectionPhotos = async (userId: number, currentUserId?: number) => {
     const collection = await findOrCreateDefaultCollection(userId);
 
-    return prisma.collectionPhoto.findMany({
+    const collectionPhotos = await prisma.collectionPhoto.findMany({
         where: {
             collectionId: collection.id,
             photo: {
@@ -98,6 +102,23 @@ export const getDefaultCollectionPhotos = async (userId: number) => {
             createdAt: 'desc',
         },
     });
+
+    const photosWithFollowStatus = await Promise.all(collectionPhotos.map(async (cp) => {
+        let authorWithFollowStatus: AuthorWithFollowStatus | undefined;
+        if (cp.photo.author) {
+            const followed = currentUserId ? await isFollowing(currentUserId, cp.photo.author.id) : false;
+            authorWithFollowStatus = { ...cp.photo.author, isFollowed: followed };
+        }
+        return {
+            ...cp,
+            photo: {
+                ...cp.photo,
+                author: authorWithFollowStatus,
+            },
+        };
+    }));
+
+    return photosWithFollowStatus;
 };
 
 /**
@@ -138,15 +159,33 @@ export const getUserCollections = async (userId: number) => {
  * @param collectionId 컬렉션 ID
  * @returns 컬렉션 상세 정보 (사진 목록 포함)
  */
-export const getCollectionDetails = async (collectionId: number) => {
-    return prisma.collection.findUnique({
+export const getCollectionDetails = async (collectionId: number, currentUserId?: number) => {
+    const collection = await prisma.collection.findUnique({
         where: {
             id: collectionId,
         },
         include: {
+            owner: {
+                select: {
+                    id: true,
+                    username: true,
+                },
+            },
             photos: {
                 include: {
-                    photo: true,
+                    photo: {
+                        include: {
+                            author: {
+                                select: {
+                                    id: true,
+                                    username: true,
+                                },
+                            },
+                            _count: {
+                                select: { likes: true },
+                            },
+                        },
+                    },
                 },
                 orderBy: {
                     createdAt: 'desc',
@@ -154,6 +193,33 @@ export const getCollectionDetails = async (collectionId: number) => {
             },
         },
     });
+
+    if (!collection) {
+        return null;
+    }
+
+    let ownerWithFollowStatus: OwnerWithFollowStatus | undefined;
+    if (collection.owner) {
+        const followed = currentUserId ? await isFollowing(currentUserId, collection.owner.id) : false;
+        ownerWithFollowStatus = { ...collection.owner, isFollowed: followed };
+    }
+
+    const photosWithFollowStatus = await Promise.all(collection.photos.map(async (cp) => {
+        let photoAuthorWithFollowStatus: AuthorWithFollowStatus | undefined;
+        if (cp.photo.author) {
+            const followed = currentUserId ? await isFollowing(currentUserId, cp.photo.author.id) : false;
+            photoAuthorWithFollowStatus = { ...cp.photo.author, isFollowed: followed };
+        }
+        return {
+            ...cp,
+            photo: {
+                ...cp.photo,
+                author: photoAuthorWithFollowStatus,
+            },
+        };
+    }));
+
+    return { ...collection, owner: ownerWithFollowStatus, photos: photosWithFollowStatus };
 };
 
 /**

--- a/src/services/photo.service.ts
+++ b/src/services/photo.service.ts
@@ -1,30 +1,33 @@
-// src/services/photo.service.ts
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Photo, User } from '@prisma/client';
 import sharp from 'sharp';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import s3Client, { bucketName } from '../lib/s3Client';
 import { getMessage } from '../utils/messageMapper';
 import config from '../config';
+import { isFollowing } from './follow.service'; // isFollowing 함수 임포트
 
 // Prisma 클라이언트 인스턴스를 생성합니다.
 const prisma = new PrismaClient();
 
+type AuthorWithFollowStatus = Pick<User, 'id' | 'username'> & { isFollowed: boolean };
+
 /**
  * 정렬 기준에 따라 사진 목록을 조회하는 서비스 함수
  * @param sortBy 정렬 기준 문자열 ('popular' 또는 그 외)
+ * @param currentUserId 현재 로그인된 사용자의 ID (선택 사항)
  * @returns 정렬된 사진 목록
  */
-export const getPhotos = async (sortBy: string) => {
+export const getPhotos = async (sortBy: string, currentUserId?: number) => {
     const whereCondition = {
         deletedAt: null, // 소프트 삭제된 사진은 제외
         isPublic: true, // 공개된 사진만 조회
     };
 
+    let photos;
+
     // 'popular' (인기순)으로 정렬하는 경우
     if (sortBy === 'popular') {
-        // Photo 모델을 직접 쿼리하면서, 관계된 PhotoLike의 개수(likes._count)를 기준으로 정렬합니다.
-        // 이 방식은 좋아요가 없는 사진도 결과에 포함시킵니다.
-        return prisma.photo.findMany({
+        photos = await prisma.photo.findMany({
             where: whereCondition,
             include: {
                 _count: {
@@ -38,7 +41,6 @@ export const getPhotos = async (sortBy: string) => {
                 }
             },
             orderBy: {
-                // likes 관계의 개수(count)를 기준으로 내림차순 정렬합니다.
                 likes: {
                     _count: 'desc',
                 },
@@ -46,7 +48,7 @@ export const getPhotos = async (sortBy: string) => {
         });
     } else {
         // 'latest' (최신순) 또는 그 외의 경우, 모든 사진을 최신순으로 정렬하여 반환합니다.
-        return prisma.photo.findMany({
+        photos = await prisma.photo.findMany({
             where: whereCondition,
             include: {
                 _count: {
@@ -60,10 +62,22 @@ export const getPhotos = async (sortBy: string) => {
                 }
             },
             orderBy: {
-                createdAt: 'desc', // 생성일(createdAt) 기준으로 내림차순 정렬
+                createdAt: 'desc',
             },
         });
     }
+
+    // 각 사진의 작성자에 대한 팔로우 상태 추가
+    const photosWithFollowStatus = await Promise.all(photos.map(async (photo) => {
+        let authorWithFollowStatus: AuthorWithFollowStatus | undefined;
+        if (photo.author) {
+            const followed = currentUserId ? await isFollowing(currentUserId, photo.author.id) : false;
+            authorWithFollowStatus = { ...photo.author, isFollowed: followed };
+        }
+        return { ...photo, author: authorWithFollowStatus };
+    }));
+
+    return photosWithFollowStatus;
 };
 
 /**
@@ -71,8 +85,8 @@ export const getPhotos = async (sortBy: string) => {
  * @param photoId 조회할 사진의 ID
  * @returns 사진, 작성자, 댓글(작성자 포함), 좋아요 정보를 포함하는 객체
  */
-export const getPhotoById = async (photoId: number) => {
-    return prisma.photo.findFirst({
+export const getPhotoById = async (photoId: number, currentUserId?: number) => {
+    const photo = await prisma.photo.findFirst({
         where: { id: { equals: photoId }, deletedAt: null, isPublic: true },
         include: {
             author: {
@@ -100,6 +114,18 @@ export const getPhotoById = async (photoId: number) => {
             },
         },
     });
+
+    if (!photo) {
+        return null;
+    }
+
+    let authorWithFollowStatus: AuthorWithFollowStatus | undefined;
+    if (photo.author) {
+        const followed = currentUserId ? await isFollowing(currentUserId, photo.author.id) : false;
+        authorWithFollowStatus = { ...photo.author, isFollowed: followed };
+    }
+
+    return { ...photo, author: authorWithFollowStatus };
 };
 
 /**

--- a/src/services/series.service.ts
+++ b/src/services/series.service.ts
@@ -1,7 +1,9 @@
-// src/services/series.service.ts
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, User } from '@prisma/client';
+import { isFollowing } from './follow.service';
 
 const prisma = new PrismaClient();
+
+type AuthorWithFollowStatus = Pick<User, 'id' | 'username'> & { profileImageUrl?: string | null; isFollowed: boolean };
 
 /**
  * 새로운 시리즈를 생성합니다.
@@ -33,10 +35,11 @@ export const createSeries = async (
 /**
  * 특정 시리즈의 상세 정보를 조회합니다.
  * @param seriesId 시리즈 ID
+ * @param currentUserId 현재 로그인된 사용자의 ID (선택 사항)
  * @returns 시리즈 객체 (사진 목록 포함) 또는 null
  */
-export const getSeriesById = async (seriesId: number) => {
-    return prisma.series.findUnique({
+export const getSeriesById = async (seriesId: number, currentUserId?: number) => {
+    const series = await prisma.series.findUnique({
         where: { id: seriesId },
         include: {
             author: {
@@ -69,6 +72,33 @@ export const getSeriesById = async (seriesId: number) => {
             },
         },
     });
+
+    if (!series) {
+        return null;
+    }
+
+    let authorWithFollowStatus: AuthorWithFollowStatus | undefined;
+    if (series.author) {
+        const followed = currentUserId ? await isFollowing(currentUserId, series.author.id) : false;
+        authorWithFollowStatus = { ...series.author, isFollowed: followed };
+    }
+
+    const photosWithFollowStatus = await Promise.all(series.photos.map(async (seriesPhoto) => {
+        let photoAuthorWithFollowStatus: AuthorWithFollowStatus | undefined;
+        if (seriesPhoto.photo.author) {
+            const followed = currentUserId ? await isFollowing(currentUserId, seriesPhoto.photo.author.id) : false;
+            photoAuthorWithFollowStatus = { ...seriesPhoto.photo.author, isFollowed: followed };
+        }
+        return {
+            ...seriesPhoto,
+            photo: {
+                ...seriesPhoto.photo,
+                author: photoAuthorWithFollowStatus,
+            },
+        };
+    }));
+
+    return { ...series, author: authorWithFollowStatus, photos: photosWithFollowStatus };
 };
 
 /**
@@ -76,8 +106,8 @@ export const getSeriesById = async (seriesId: number) => {
  * @param userId 사용자 ID
  * @returns 시리즈 목록
  */
-export const getUserSeries = async (userId: number) => {
-    return prisma.series.findMany({
+export const getUserSeries = async (userId: number, currentUserId?: number) => {
+    const seriesList = await prisma.series.findMany({
         where: { userId },
         orderBy: { createdAt: 'desc' },
         include: {
@@ -85,8 +115,25 @@ export const getUserSeries = async (userId: number) => {
             _count: {
                 select: { photos: true }, // 시리즈에 포함된 사진 수
             },
+            author: {
+                select: {
+                    id: true,
+                    username: true,
+                },
+            },
         },
     });
+
+    const seriesWithFollowStatus = await Promise.all(seriesList.map(async (series) => {
+        let authorWithFollowStatus: AuthorWithFollowStatus | undefined;
+        if (series.author) {
+            const followed = currentUserId ? await isFollowing(currentUserId, series.author.id) : false;
+            authorWithFollowStatus = { ...series.author, isFollowed: followed };
+        }
+        return { ...series, author: authorWithFollowStatus };
+    }));
+
+    return seriesWithFollowStatus;
 };
 
 /**


### PR DESCRIPTION
- 팔로우/언팔로우 기능을 단일 토글 엔드포인트로 리팩토링하여 사용자 경험 및 일관성 향상.
- 사용자, 사진, 시리즈, 컬렉션 데이터에 `isFollowed` 상태를 추가하여 실시간 팔로우 정보 제공.
- Prisma 스키마 관계 및 타입 유효성 검사 오류를 해결하여 데이터 무결성 및 올바른 타입 추론 보장.